### PR TITLE
Fixed wrong constant being used

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenOperation.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenOperation.java
@@ -484,7 +484,7 @@ public class CodegenOperation extends CodegenObject {
     }
 
     public Boolean getIsRestfulDestroy() {
-        return getBooleanValue(CodegenConstants.IS_RESTFUL_UPDATE_EXT_NAME);
+        return getBooleanValue(CodegenConstants.IS_RESTFUL_DESTROY_EXT_NAME);
     }
 
     public Boolean getIsRestful() {


### PR DESCRIPTION
The method getIsRestfulDestroy would return if it's a REST update instead of a REST delete because the wrong constant was used, probably a copy/paste error.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Simple fix to change the wrong constant being used in CodegenOperation.getIsRestfulDestroy()

